### PR TITLE
docs: add MQ and SOAP entries to integrations listAdd MQ Pub/Sub and two SOAP-related entries to the integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 The goal is to document all the different integrations available, and their state
 
-[x] Calling JSON API
-[ ] Calling API with OpenAPI (Status: Struggling to get it working properly)
-[ ] Publishing and subscribing to Kafka (Status: Deps outdated in library)
+- [x] Calling JSON API
+- [ ] Calling API with OpenAPI (Status: Struggling to get it working properly)
+- [ ] Publishing and subscribing to Kafka (Status: Deps outdated in library)
+- [ ] MQ Pub/Sub (Status: Depds outdated in library)
+- [ ] SOAP web service (No Gleam deps)
+- [ ] Calling SOAP services (No Gleam deps)


### PR DESCRIPTION
checklist in README. These new lines document missing or outdated
dependencies and highlight areas where Gleam compatibility is lacking.

This clarifies current gaps (MQ deps outdated; no Gleam deps for SOAP)
so contributors can prioritize investigation and fixes.